### PR TITLE
Added keyboard shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ dist/**
 node_modules/**
 public/docs/user-guide.html
 yarn.lock
+.idea/.gitignore
+.idea/CIMDiagramLayoutEditor.iml
+.idea/modules.xml
+.idea/vcs.xml

--- a/docs/user-guide.adoc
+++ b/docs/user-guide.adoc
@@ -190,32 +190,89 @@ When moving multiple points, the first selected point will snap to the grid, and
 |===
 |Shortcut |Function
 
+|*Navigation*
+|
+
+|kbd:[Arrow Keys]
+|Pan the canvas by grid size
+
+|kbd:[Shift] + Arrow Keys
+|Pan the canvas by 10x grid size
+
+|kbd:[Alt] + Arrow Keys
+|Pan the canvas precisely by 1 unit
+
+|kbd:[Ctrl] + kbd:[+]
+|Zoom in
+
+|kbd:[Ctrl] + kbd:[-]
+|Zoom out
+
+|kbd:[Ctrl] + kbd:[Shift] + kbd:[+]
+|Zoom in with larger steps
+
+|kbd:[Ctrl] + kbd:[Alt] + kbd:[+]
+|Zoom in with smaller steps
+
+|kbd:[Ctrl] + kbd:[0]
+|Reset zoom to 100%
+
+|kbd:[Ctrl] + kbd:[F]
+|Fit diagram to view
+
+|kbd:[Space]
+|Temporarily activate pan mode (hold)
+
+|*Selection & Control*
+|
+
 |kbd:[Ctrl] + Click
 |Select a point
 
 |kbd:[Ctrl] + Drag
 |Select multiple points within a rectangle
 
+|kbd:[Esc]
+|Clear selection or close active tooltip
+
+|kbd:[Ctrl] + kbd:[A]
+|Select all objects
+
+|*Object Movement*
+|
+
+|kbd:[Ctrl] + Arrow Keys
+|Move selected objects by grid size
+
+|kbd:[Ctrl] + kbd:[Shift] + Arrow Keys
+|Move selected objects by 10x grid size
+
+|kbd:[Ctrl] + kbd:[Alt] + Arrow Keys
+|Move selected objects precisely by 1 unit
+
 |kbd:[Alt] + Drag
 |Move selected points with grid snapping temporarily disabled
 
-|kbd:[Ctrl+C]
+|*Object Manipulation*
+|
+
+|kbd:[Ctrl] + kbd:[C]
 |Copy selected diagram objects
 
-|kbd:[Ctrl+V]
+|kbd:[Ctrl] + kbd:[V]
 |Paste copied objects at cursor position
+
+|kbd:[Ctrl] + kbd:[D]
+|Duplicate selected objects with offset
 
 |kbd:[Delete]
 |Delete selected diagram objects
 
-|kbd:[Ctrl+Right Arrow]
+|kbd:[Ctrl] + kbd:[Right Arrow]
 |Rotate selected objects 90° clockwise
 
-|kbd:[Ctrl+Left Arrow]
+|kbd:[Ctrl] + kbd:[Left Arrow]
 |Rotate selected objects 90° counter-clockwise
-
-|kbd:[Esc]
-|Close active tooltip
 |===
 
 == Point Tooltips

--- a/src/features/interaction/InteractionState.ts
+++ b/src/features/interaction/InteractionState.ts
@@ -353,3 +353,11 @@ export function endPanning(): void {
     panStart: null
   }));
 }
+
+export const tempPanState = writable<{
+  previousMode: InteractionMode,
+  enabled: boolean
+}>({
+  previousMode: InteractionMode.NONE,
+  enabled: false
+});


### PR DESCRIPTION
# Enhanced Keyboard Navigation and Shortcuts

This PR adds comprehensive keyboard shortcuts to improve the usability and accessibility of the CGMES DiagramLayout Editor.

## New Features
- **Canvas Navigation**: Arrow keys for panning (with Shift for 10x speed and Alt for precise 1-unit movement)
- **Object Manipulation**: Ctrl+Arrow keys to move selected objects (with same Shift/Alt modifiers)
- **Zoom Controls**: Ctrl+Plus/Minus with Shift/Alt modifiers for different zoom increments
- **Selection**: Ctrl+A to select all objects
- **View Management**: Ctrl+F to fit diagram to view, Ctrl+0 to reset zoom
- **Efficiency Tools**: Ctrl+D to duplicate selected objects, Spacebar for temporary pan mode

These keyboard shortcuts follow common conventions from similar CAD/diagram applications to create an intuitive user experience while significantly improving workflow efficiency.