### PR TITLE
Fix: Improve glue point selection handling

### DIFF
--- a/src/features/gluepoints/GluePointService.ts
+++ b/src/features/gluepoints/GluePointService.ts
@@ -8,6 +8,7 @@ import type { DiagramService } from '@/features/diagram/DiagramService';
 import { diagramData, cimNamespace } from '../diagram/DiagramState';
 import { setLoading, updateStatus } from '../ui/UIState';
 import type { GluePointQueryBuilder } from '@/queries/GluePointQueryBuilder ';
+import { selectedGluePoint } from './GluePointState';
 import { interactionState, clearSelection, togglePointSelection } from '../interaction/InteractionState';
 
 export class GluePointService {
@@ -153,6 +154,9 @@ export class GluePointService {
       // Update the UI state
       diagramData.set(currentDiagram);
 
+       // Set the newly created glue point as selected
+      selectedGluePoint.set(gluePointIri);
+      
       updateStatus('Glue point created successfully');
       return gluePoint;
 

--- a/src/features/interaction/actions/canvasInteraction.ts
+++ b/src/features/interaction/actions/canvasInteraction.ts
@@ -84,7 +84,8 @@ export function canvasInteraction(canvas: HTMLCanvasElement) {
     
     // If Escape is pressed and no tooltip is showing, clear selection
     if (e.key === 'Escape') {
-      clearSelection();
+      clearSelection();      
+      selectedGluePoint.set(null); // Clear selected glue point if any
       return;
     }
     
@@ -645,12 +646,22 @@ export function canvasInteraction(canvas: HTMLCanvasElement) {
         if (!anyPoint) {
           // Clicked on empty space, clear selection
           clearSelection();
+          if (get(selectedGluePoint) !== null) { // Clear selected glue point if any
+            selectedGluePoint.set(null); 
+          }
         }        
         // Start panning
         startPanning({ x: screenX, y: screenY });
       }
     } else {
-      // No points selected, start panning
+      // No points selected
+
+      // If a glue point is selected, deselect it when clicking elsewhere
+      if (get(selectedGluePoint) !== null) {
+        selectedGluePoint.set(null);
+      }
+
+      // // start panning
       startPanning({ x: screenX, y: screenY });
     }
   }


### PR DESCRIPTION
This commit addresses two issues related to glue point selection behavior:

1.  Ensures selected glue points are deselected when clicking elsewhere on the canvas. Modified `handleMouseDown` in `src/features/interaction/actions/canvasInteraction.ts` to clear the `selectedGluePoint` state on relevant clicks.

2.  Automatically selects newly created glue points. Updated the `createGluePoint` method in `src/features/gluepoints/GluePointService.ts` to set the `selectedGluePoint` state to the IRI of the newly created glue point immediately after successful creation.