### PR TITLE
feat: Add horizontal and vertical mirroring functionality

### DIFF
--- a/docs/user-guide.adoc
+++ b/docs/user-guide.adoc
@@ -118,6 +118,12 @@ You can permanently toggle the snap-to-grid behavior using the checkbox in the G
 
 |*Rotate Counter-clockwise*
 |Select points and click the -90° button in the control panel to rotate 90° counter-clockwise
+
+|*Mirror Horizontally*
+|Select points and click the ↔ button in the control panel to mirror horizontally across the center of selection
+
+|*Mirror Vertically*
+|Select points and click the ↕ button in the control panel to mirror vertically across the center of selection
 |===
 
 == Navigation Map

--- a/docs/user-guide.adoc
+++ b/docs/user-guide.adoc
@@ -180,6 +180,12 @@ The navigation map is especially useful for very large diagrams where it's easy 
 
 |*-90° Button*
 |Rotate selected objects 90 degrees counter-clockwise
+
+|*↔ Button*
+|Mirror selected objects horizontally across the center of selection
+
+|*↕ Button*
+|Mirror selected objects vertically across the center of selection
 |===
 
 === Grid Snapping Controls

--- a/src/features/diagram/components/ConfigPanel.svelte
+++ b/src/features/diagram/components/ConfigPanel.svelte
@@ -100,6 +100,44 @@
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
+
+  // Handle mirror horizontally button click
+  async function handleMirrorHorizontally() {
+    try {
+      // Check if any points are selected
+      const selectedPoints = $interactionState.selectedPoints;
+      if (selectedPoints.size === 0) {
+        updateStatus('No objects selected for mirroring');
+        return;
+      }
+
+      const success = await objectService.mirrorSelectedObjectsHorizontally();
+      if (success) {
+        updateStatus(`Mirrored objects horizontally`);
+      }
+    } catch (error) {
+      updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  // Handle mirror vertically button click
+  async function handleMirrorVertically() {
+    try {
+      // Check if any points are selected
+      const selectedPoints = $interactionState.selectedPoints;
+      if (selectedPoints.size === 0) {
+        updateStatus('No objects selected for mirroring');
+        return;
+      }
+
+      const success = await objectService.mirrorSelectedObjectsVertically();
+      if (success) {
+        updateStatus(`Mirrored objects vertically`);
+      }
+    } catch (error) {
+      updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
 </script>
 
 <div class="config-panel">
@@ -187,13 +225,29 @@
     <Button
             id="rotate-ccw"
             label="-90°"
+            tooltip="Rotate 90° counter-clockwise"
             on:click={() => handleRotate(-90)}
             disabled={loading}>
     </Button>
     <Button
             id="rotate-cw"
             label="+90°"
+            tooltip="Rotate 90° clockwise"
             on:click={() => handleRotate(90)}
+            disabled={loading}>
+    </Button>
+    <Button
+            id="mirror-h"
+            label="↔"
+            tooltip="Mirror horizontally"
+            on:click={handleMirrorHorizontally}
+            disabled={loading}>
+    </Button>
+    <Button
+            id="mirror-v"
+            label="↕"
+            tooltip="Mirror vertically"
+            on:click={handleMirrorVertically}
             disabled={loading}>
     </Button>
   </div>

--- a/src/features/ui/base-components/Button.svelte
+++ b/src/features/ui/base-components/Button.svelte
@@ -4,13 +4,15 @@
     export let type: 'button' | 'submit' | 'reset' = 'button';
     export let disabled: boolean = false;
     export let primary: boolean = true;
-  </script>
+    export let tooltip: string | undefined = undefined;
+</script>
   
   <button 
     {id} 
-    {type} 
+    {type}
     {disabled} 
-    class:primary 
+    class:primary
+    title={tooltip}
     on:click
   >
     {label}


### PR DESCRIPTION
feat: Add horizontal and vertical mirroring functionality
- Add mirror horizontally (↔) and mirror vertically (↕) buttons to transformation controls
- Implement mirrorSelectedObjectsHorizontally and mirrorSelectedObjectsVertically methods in ObjectService
- Add supporting calculation methods for mirroring transformations
- Add tooltip support to Button component for improved UI/UX
- Extend transform validation logic to support all transformation types

The mirroring functionality allows users to reflect selected diagram objects
across horizontal or vertical axes centered on the object selection.