### PR TITLE
refactor: move point transformations to PointService

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,33 @@ The application was largely generated using artificial intelligence, primarily u
 - **Navigation Map**: Mini-map in corner for navigating large diagrams
 - **Responsive Design**: Adapts to different screen sizes and devices
 
+### Transformation Operations
+
+#### Point-Based Transformations
+
+The CGMES DiagramLayout Editor uses point-based transformation operations for rotation and mirroring. This means:
+
+- **Direct Point Control**: Rotations and mirroring operations work directly on the selected points
+- **Granular Control**: You can transform partial objects by selecting only some of their points
+- **No Automatic Expansion**: Selecting a point doesn't automatically select all points of its parent object
+
+#### Working with Transformations
+
+1. **Select Points**: Use Ctrl+Click or Ctrl+Drag to select the points you want to transform
+2. **Transform**: Click the rotation (+90°/-90°) or mirroring (↔/↕) buttons
+3. **Whole Objects**: To transform entire objects, first select all their points using:
+  - Ctrl+Drag to create a selection rectangle
+  - Ctrl+C to copy objects (which selects all their points)
+
+### Navigation Map
+
+The editor features a navigation map in the lower right corner that:
+
+- Shows a miniature view of the entire diagram
+- Highlights the currently visible portion of the diagram
+- Allows quick navigation by clicking or dragging within the map
+- Helps maintain context when working with large diagrams
+
 ### Glue Point Support
 
 #### DiagramObjectGluePoint
@@ -151,15 +178,6 @@ The editor follows a clean architecture with clear separation of concerns:
 - **Services**: Handle SPARQL communication and application services
 - **Queries**: SPARQL query builders for different operations
 - **Utils**: Utility functions for geometry, canvas operations, etc.
-
-### Navigation Map
-
-The editor features a navigation map in the lower right corner that:
-
-- Shows a miniature view of the entire diagram
-- Highlights the currently visible portion of the diagram
-- Allows quick navigation by clicking or dragging within the map
-- Helps maintain context when working with large diagrams
 
 ### SPARQL Implementation
 

--- a/docs/user-guide.adoc
+++ b/docs/user-guide.adoc
@@ -181,18 +181,85 @@ The navigation map is especially useful for very large diagrams where it's easy 
 |*Show Glue Connections*
 |Toggle to display dotted lines between glued points
 
-|*+90° Button*
-|Rotate selected objects 90 degrees clockwise
-
-|*-90° Button*
-|Rotate selected objects 90 degrees counter-clockwise
-
-|*↔ Button*
-|Mirror selected objects horizontally across the center of selection
-
-|*↕ Button*
-|Mirror selected objects vertically across the center of selection
 |===
+
+=== Transformation Operations
+
+==== Point-Based Transformations
+
+The CGMES DiagramLayout Editor uses a point-based approach for rotation and mirroring operations. This provides granular control over your diagram edits.
+
+[cols="1,3"]
+|===
+|Action |Description
+
+|*Rotate Selected Points*
+|Click the +90° or -90° buttons to rotate the currently selected points. The rotation center is calculated as the geometric center of all selected points.
+
+|*Mirror Selected Points*
+|Click the ↔ or ↕ buttons to mirror the currently selected points horizontally or vertically. The mirror axis passes through the geometric center of the selected points.
+
+|*Transform Entire Objects*
+|To rotate or mirror entire objects, first select all points of those objects. You can use Ctrl+C to copy objects (which selects all their points) or manually select all points of the objects you want to transform.
+
+|===
+
+==== Working with Point-Based Transformations
+
+The point-based transformation system provides several advantages:
+
+* **Granular Control**: You can transform only part of an object by selecting specific points
+* **Partial Transformations**: Create complex modifications by transforming different parts of objects independently
+* **Precise Selection**: Use Ctrl+Click to select individual points or Ctrl+Drag to select multiple points
+* **Flexible Workflow**: Mix partial and complete transformations as needed
+
+===== Selection Strategies
+
+[cols="1,3"]
+|===
+|Method |Description
+
+|*Ctrl+Click*
+|Select individual points one at a time
+
+|*Ctrl+Drag*
+|Create a selection rectangle to select multiple points at once
+
+|*Ctrl+C*
+|Copy objects (which selects all their points)
+
+|*Ctrl+C then Ctrl+V*
+|Copy objects (which selects all their points) and use for transformation
+
+|*Ctrl+A*
+|Select all points in the diagram
+
+|===
+
+[NOTE]
+====
+Remember that transformations affect only the selected points. If you're used to object-based transformations from other tools, take care to select all points of objects you want to transform completely.
+====
+
+[TIP]
+====
+To quickly select all points of an object, select any point of that object and press Ctrl+C to copy. This automatically selects all points of the parent object.
+====
+
+
+
+==== Best Practices
+
+* **Visual Feedback**: Selected points are highlighted in red to show what will be transformed
+* **Plan Your Selection**: Think about which points you want to transform before applying operations
+* **Use the Grid**: Enable grid snapping to align transformed points precisely
+* **Preview Selection**: Check your selection before transforming - the status bar shows how many points are selected
+* **Mix Techniques**: Combine different selection methods for complex transformations
+
+[WARNING]
+====
+Transformations cannot be undone automatically. Always check your selection before applying transformations, especially on complex diagrams.
+====
 
 === Grid Snapping Controls
 

--- a/src/features/diagram/components/ConfigPanel.svelte
+++ b/src/features/diagram/components/ConfigPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { 
+  import {
     diagramList,
     selectedDiagram,
     cgmesVersion,
@@ -16,40 +16,41 @@
   import Input from '../../ui/base-components/Input.svelte';
   import { showGluePoints } from '../../gluepoints/GluePointState';
   import { interactionState } from '../../interaction/InteractionState';
-  
-  // Get service
+
+  // Get services
   const diagramService = serviceRegistry.diagramService;
   const objectService = serviceRegistry.objectService;
-  
+  const pointService = serviceRegistry.pointService; // Add point service for transformations
+
   // Props
-  let { 
-    onLoadDiagrams, 
-    onRenderDiagram, 
-    onToggleMap } 
-    : {
+  let {
+    onLoadDiagrams,
+    onRenderDiagram,
+    onToggleMap }
+          : {
     onLoadDiagrams: (endpoint: string) => void,
     onRenderDiagram: (diagramIri: string) => void,
-    onToggleMap: (show: boolean) => void,    
-    } = $props();
-  
+    onToggleMap: (show: boolean) => void,
+  } = $props();
+
   // Local state
   let endpoint = $state(AppConfig.defaultEndpoint);
   let showNavigationMap = $state(true);
 
   let loading = $state(true);
   isLoading.subscribe(value => loading = value);
-    
+
   // Options for CGMES version radio buttons
   const versionOptions = [
     { value: CGMESVersion.V2_4_15, label: '2.4.15' },
     { value: CGMESVersion.V3_0, label: '3.0' }
   ];
-    
+
   // Handle CGMES version change
   function handleVersionChange(version: string) {
     setCGMESVersion(version as CGMESVersion);
   }
-  
+
   // Handle load diagrams button click
   async function handleLoadDiagrams() {
     try {
@@ -59,7 +60,7 @@
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
-  
+
   // Handle render diagram button click
   async function handleRenderDiagram() {
     try {
@@ -69,12 +70,12 @@
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
-  
+
   // Handle diagram selection change
   function handleDiagramChange(diagramIri: string) {
     selectedDiagram.set(diagramIri);
   }
-  
+
   // Handle navigation map toggle
   function toggleNavigationMap() {
     // Just dispatch the current state - don't invert here
@@ -88,13 +89,13 @@
       // Check if any points are selected
       const selectedPoints = $interactionState.selectedPoints;
       if (selectedPoints.size === 0) {
-        updateStatus('No objects selected for rotation');
+        updateStatus('No points selected for rotation');
         return;
       }
 
-      const success = await objectService.rotateSelectedObjects(degrees);
+      const success = await pointService.rotateSelectedPoints(degrees);
       if (success) {
-        updateStatus(`Rotated objects by ${degrees} degrees`);
+        updateStatus(`Rotated ${selectedPoints.size} points by ${degrees} degrees`);
       }
     } catch (error) {
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -107,13 +108,13 @@
       // Check if any points are selected
       const selectedPoints = $interactionState.selectedPoints;
       if (selectedPoints.size === 0) {
-        updateStatus('No objects selected for mirroring');
+        updateStatus('No points selected for mirroring');
         return;
       }
 
-      const success = await objectService.mirrorSelectedObjectsHorizontally();
+      const success = await pointService.mirrorSelectedPointsHorizontally();
       if (success) {
-        updateStatus(`Mirrored objects horizontally`);
+        updateStatus(`Mirrored ${selectedPoints.size} points horizontally`);
       }
     } catch (error) {
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -126,13 +127,13 @@
       // Check if any points are selected
       const selectedPoints = $interactionState.selectedPoints;
       if (selectedPoints.size === 0) {
-        updateStatus('No objects selected for mirroring');
+        updateStatus('No points selected for mirroring');
         return;
       }
 
-      const success = await objectService.mirrorSelectedObjectsVertically();
+      const success = await pointService.mirrorSelectedPointsVertically();
       if (success) {
-        updateStatus(`Mirrored objects vertically`);
+        updateStatus(`Mirrored ${selectedPoints.size} points vertically`);
       }
     } catch (error) {
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -142,50 +143,50 @@
 
 <div class="config-panel">
   <div class="input-group">
-    <Input 
-      id="endpoint" 
-      label="SPARQL Endpoint URL:" 
-      bind:value={endpoint} 
-      disabled={loading}
+    <Input
+            id="endpoint"
+            label="SPARQL Endpoint URL:"
+            bind:value={endpoint}
+            disabled={loading}
     />
   </div>
-  
+
   <div class="input-group">
-    <RadioGroup 
-      legend="CGMES Version:" 
-      name="cgmes_version" 
-      options={versionOptions} 
-      value={$cgmesVersion} 
-      change={handleVersionChange} 
-      disabled={loading}>
+    <RadioGroup
+            legend="CGMES Version:"
+            name="cgmes_version"
+            options={versionOptions}
+            value={$cgmesVersion}
+            change={handleVersionChange}
+            disabled={loading}>
     </RadioGroup>
   </div>
-  
+
   <div class="input-group">
-    <Select 
-      id="diagram-select" 
-      label="Select diagram:" 
-      options={$diagramList.map(d => ({ value: d.iri, label: d.name }))}
-      value={$selectedDiagram}
-      required={true}
-      change={handleDiagramChange}
-      disabled={loading || $diagramList.length === 0}
-      placeholder="-- Select a diagram --">
+    <Select
+            id="diagram-select"
+            label="Select diagram:"
+            options={$diagramList.map(d => ({ value: d.iri, label: d.name }))}
+            value={$selectedDiagram}
+            required={true}
+            change={handleDiagramChange}
+            disabled={loading || $diagramList.length === 0}
+            placeholder="-- Select a diagram --">
     </Select>
   </div>
-  
+
   <div class="button-group">
-    <Button 
-      id="load-diagrams" 
-      label="Load diagram profiles" 
-      on:click={handleLoadDiagrams} 
-      disabled={loading}>
+    <Button
+            id="load-diagrams"
+            label="Load diagram profiles"
+            on:click={handleLoadDiagrams}
+            disabled={loading}>
     </Button>
-    <Button 
-      id="render-diagram" 
-      label="Render diagram" 
-      on:click={handleRenderDiagram} 
-      disabled={loading || !$selectedDiagram}>
+    <Button
+            id="render-diagram"
+            label="Render diagram"
+            on:click={handleRenderDiagram}
+            disabled={loading || !$selectedDiagram}>
     </Button>
   </div>
 </div>
@@ -200,12 +201,12 @@
   <div class="grid-size">
     <label>
       Grid Size:
-      <input 
-        type="number" 
-        bind:value={$gridSize} 
-        min="5" 
-        max="100" 
-        step="5"
+      <input
+              type="number"
+              bind:value={$gridSize}
+              min="5"
+              max="100"
+              step="5"
       />
     </label>
     <label class="show-map-label">
@@ -225,49 +226,51 @@
     <Button
             id="rotate-ccw"
             label="-90°"
-            tooltip="Rotate 90° counter-clockwise"
+            tooltip="Rotate selected points 90° counter-clockwise"
             on:click={() => handleRotate(-90)}
             disabled={loading}>
     </Button>
     <Button
             id="rotate-cw"
             label="+90°"
-            tooltip="Rotate 90° clockwise"
+            tooltip="Rotate selected points 90° clockwise"
             on:click={() => handleRotate(90)}
             disabled={loading}>
     </Button>
     <Button
             id="mirror-h"
             label="↔"
-            tooltip="Mirror horizontally"
+            tooltip="Mirror selected points horizontally"
             on:click={handleMirrorHorizontally}
             disabled={loading}>
     </Button>
     <Button
             id="mirror-v"
             label="↕"
-            tooltip="Mirror vertically"
+            tooltip="Mirror selected points vertically"
             on:click={handleMirrorVertically}
             disabled={loading}>
     </Button>
   </div>
 </div>
 
-
+<div class="transformation-hint">
+  <span class="hint-text">Transformations work on selected points only. Use Ctrl+C to select whole Diagram Objects.</span>
+</div>
 
 <style>
   .config-panel {
     display: flex;
-    flex-wrap: wrap;      
+    flex-wrap: wrap;
     gap: var(--spacing-lg);
     margin-bottom: var(--spacing-lg);
   }
-  
+
   .input-group {
     flex: 1;
     min-width: 200px;
   }
-  
+
   .button-group {
     display: flex;
     gap: var(--spacing-md);
@@ -285,19 +288,19 @@
     border-radius: var(--border-radius);
     background-color: #f9f9f9;
   }
-  
+
   .checkbox-group {
     display: flex;
     gap: var(--spacing-lg);
   }
-  
+
   .checkbox-group label {
     display: flex;
     align-items: center;
     gap: var(--spacing-xs);
     cursor: pointer;
   }
-  
+
   .grid-size {
     display: flex;
     align-items: center;
@@ -307,12 +310,12 @@
 
   .grid-size input[type="number"] {
     width: 50px;
-    text-align: right;      
+    text-align: right;
     padding: 3px;
     border: 1px solid var(--border-color);
     border-radius: 3px;
   }
-  
+
   .show-map-label {
     display: flex;
     align-items: center;
@@ -333,5 +336,19 @@
     gap: var(--spacing-md);
     margin-left: auto;
     align-items: center;
+    border-left: 1px solid var(--border-color);
+    padding-left: var(--spacing-lg);
+  }
+
+  .transformation-hint {
+    margin-top: var(--spacing-sm);
+    text-align: center;
+    width: 100%;
+  }
+
+  .hint-text {
+    font-size: 0.75rem;
+    font-style: italic;
+    color: #666;
   }
 </style>

--- a/src/features/interaction/actions/canvasInteraction.ts
+++ b/src/features/interaction/actions/canvasInteraction.ts
@@ -139,14 +139,6 @@ export function canvasInteraction(canvas: HTMLCanvasElement) {
       } else if (e.key === 'v') {
         // Paste operation
         pasteDiagramObjects(currentMouseWorldPos);
-      } else if (e.key === 'ArrowRight') {
-        // Rotate 90 degrees clockwise
-        e.preventDefault(); 
-        rotateSelectedObjects(90);
-      } else if (e.key === 'ArrowLeft') {
-        // Rotate 90 degrees counter-clockwise
-        e.preventDefault();
-        rotateSelectedObjects(-90);
       }
     } else if (e.key === 'Delete') {
       // First, check if a glue point marker itself is selected
@@ -752,13 +744,6 @@ export function canvasInteraction(canvas: HTMLCanvasElement) {
    */
   function deleteSelectedDiagramObjects() {
     objectService.deleteSelectedDiagramObjects();
-  }
-
-  /**
-   * Rotate selected objects around the center of selection
-   */
-  function rotateSelectedObjects(degrees: number) {
-    objectService.rotateSelectedObjects(degrees);
   }
 
   function findClosestGlueConnection(worldPos: Point2D, diagram: DiagramModel, threshold: number): {point1: string, point2: string} | null {

--- a/src/features/points/PointService.ts
+++ b/src/features/points/PointService.ts
@@ -9,64 +9,64 @@ import { PointQueryBuilder } from '@/queries/PointQueryBuilder';
 // Import state from feature modules
 import { diagramData, cimNamespace } from '../diagram/DiagramState';
 import { setLoading, updateStatus } from '../ui/UIState';
-import { clearSelection, togglePointSelection } from '../interaction/InteractionState';
+import { clearSelection, togglePointSelection, interactionState } from '../interaction/InteractionState';
 import type { ObjectQueryBuilder } from '@/queries/ObjectQueryBuilder';
 import type { DiagramService } from '../diagram/DiagramService';
 
 export class PointService {
   constructor(
-    private sparqlService: SparqlService,
-    private pointQueryBuilder: PointQueryBuilder,
-    private objectQueryBuilder: ObjectQueryBuilder,
-    private diagramService: DiagramService
+      private sparqlService: SparqlService,
+      private pointQueryBuilder: PointQueryBuilder,
+      private objectQueryBuilder: ObjectQueryBuilder,
+      private diagramService: DiagramService
   ) {}
 
   /**
    * Add a new point to a line in the diagram
    */
   async addNewPointToLine(
-    object: DiagramObjectModel,
-    position: Point2D,
-    insertIndex: number
+      object: DiagramObjectModel,
+      position: Point2D,
+      insertIndex: number
   ): Promise<boolean> {
     if (!object || !position || insertIndex === undefined) return false;
-    
+
     const currentDiagram = get(diagramData);
     if (!currentDiagram) return false;
-    
+
     // Generate a new unique IRI for the point
     const newPointIri = `urn:uuid:${uuidv4()}`;
 
     try {
       setLoading(true);
       updateStatus('Adding new point...');
-      
+
       // Create new point
       const newPoint = new PointModel(
-        newPointIri,
-        position.x,
-        position.y,
-        insertIndex, // Initial sequence number at insert position
-        object
+          newPointIri,
+          position.x,
+          position.y,
+          insertIndex, // Initial sequence number at insert position
+          object
       );
-      
+
       // Insert the point into the object's points array
       object.points.splice(insertIndex, 0, newPoint);
-      
+
       // Update sequence numbers for all points in the object
       object.points.forEach((point, index) => {
         point.sequenceNumber = index;
       });
-      
+
       // Add point to the diagram's points collection
       currentDiagram.points.push(newPoint);
-      
+
       // Update the diagram in the UI
       diagramData.set(currentDiagram);
-      
+
       // Get the current namespace
       const namespace = get(cimNamespace);
-      
+
       // Create data for SPARQL update
       const pointUpdateData = {
         iri: newPointIri,
@@ -75,36 +75,36 @@ export class PointService {
         y: position.y,
         sequenceNumber: insertIndex
       };
-      
+
       // Prepare sequence number updates for all points in the object
       const sequenceUpdates = object.points.map(point => ({
         iri: point.iri,
         sequenceNumber: point.sequenceNumber
       }));
-      
+
       // Persist changes to the database
       // First insert the new point
       const insertQuery = this.pointQueryBuilder.buildInsertPointQuery(
-        pointUpdateData.iri,
-        pointUpdateData.objectIri,
-        pointUpdateData.x,
-        pointUpdateData.y,
-        pointUpdateData.sequenceNumber,
-        namespace
+          pointUpdateData.iri,
+          pointUpdateData.objectIri,
+          pointUpdateData.x,
+          pointUpdateData.y,
+          pointUpdateData.sequenceNumber,
+          namespace
       );
-      
+
       await this.sparqlService.executeUpdate(insertQuery);
-      
+
       // Then update all sequence numbers
       const updateSequenceQuery = this.pointQueryBuilder.buildUpdateSequenceNumbersQuery(
-        sequenceUpdates,
-        namespace
+          sequenceUpdates,
+          namespace
       );
-      
+
       await this.sparqlService.executeUpdate(updateSequenceQuery);
-      
+
       updateStatus('New point added');
-      
+
       // Select the newly added point
       clearSelection();
       togglePointSelection(newPointIri);
@@ -113,94 +113,94 @@ export class PointService {
     } catch (error) {
       console.error('Error adding new point:', error);
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
-      
+
       await this.diagramService.reloadDiagram();
       return false;
     } finally {
       setLoading(false);
     }
   }
-  
+
   /**
    * Delete a point from a line in the diagram
    */
   async deletePointFromLine(point: PointModel): Promise<boolean> {
     if (!point) return false;
-    
+
     const currentDiagram = get(diagramData);
     if (!currentDiagram) return false;
-    
+
     // Get the parent object
     const object = point.parentObject;
     if (!object) {
       updateStatus('Cannot delete point: parent object not found');
       return false;
     }
-    
+
     try {
       // Check if the point is first or last in its object
       const pointIndex = object.points.findIndex(p => p.iri === point.iri);
-      
+
       // For non-polygon objects (lines), prevent deletion of first and last points
       if (!object.isPolygon && (pointIndex === 0 || pointIndex === object.points.length - 1)) {
         updateStatus('Cannot delete first or last point of a line');
         return false;
       }
-      
+
       // At this point we know we can delete the point
       setLoading(true);
       updateStatus('Deleting point...');
-      
+
       // Remove the point from the object's points array
       object.points.splice(pointIndex, 1);
-      
+
       // Check if the object was a polygon and needs to be updated
       let needsPolygonUpdate = false;
 
-      // If we have fewer than 3 points and it was a polygon, remove the polygon property      
+      // If we have fewer than 3 points and it was a polygon, remove the polygon property
       if(object.isPolygon && object.points.length < 3) {
         object.isPolygon = false;
         needsPolygonUpdate = true;
       }
-      
+
       // Update sequence numbers for all remaining points
       object.points.forEach((p, index) => {
         p.sequenceNumber = index;
       });
-      
+
       // Persist changes to the database
 
       // Get the current namespace
       const namespace = get(cimNamespace);
-      
+
       // Prepare sequence number updates for all points in the object
       const sequenceUpdates = object.points.map((p: { iri: any; sequenceNumber: any; }) => ({
         iri: p.iri,
         sequenceNumber: p.sequenceNumber
       }));
-      
+
 
       // Delete the point
       const deletePointQuery = this.pointQueryBuilder.buildDeletePointQuery(
-        point.iri,
-        namespace
+          point.iri,
+          namespace
       );
       await this.sparqlService.executeUpdate(deletePointQuery);
 
       // Update sequence numbers
-       const updateSequenceQuery = this.pointQueryBuilder.buildUpdateSequenceNumbersQuery(
-        sequenceUpdates,
-        namespace
-      );      
+      const updateSequenceQuery = this.pointQueryBuilder.buildUpdateSequenceNumbersQuery(
+          sequenceUpdates,
+          namespace
+      );
       await this.sparqlService.executeUpdate(updateSequenceQuery);
 
       // If the object was a polygon and now has fewer than 3 points, update the polygon property
       if (needsPolygonUpdate) {
-        
+
         const updatePolygonQuery = this.objectQueryBuilder.buildUpdatePolygonPropertyQuery(
-          object.iri,
-          false,
-          namespace
+            object.iri,
+            false,
+            namespace
         );
         await this.sparqlService.executeUpdate(updatePolygonQuery);
 
@@ -208,48 +208,48 @@ export class PointService {
 
       // Update the diagram in the UI
 
-       // Remove from diagram points collection
-       const diagramPointIndex = currentDiagram.points.findIndex(p => p.iri === point.iri);
-       if (diagramPointIndex >= 0) {
-         currentDiagram.points.splice(diagramPointIndex, 1);
-       }
-       
-       // Update the diagram in the UI
-       diagramData.set(currentDiagram);
-      
+      // Remove from diagram points collection
+      const diagramPointIndex = currentDiagram.points.findIndex(p => p.iri === point.iri);
+      if (diagramPointIndex >= 0) {
+        currentDiagram.points.splice(diagramPointIndex, 1);
+      }
+
+      // Update the diagram in the UI
+      diagramData.set(currentDiagram);
+
       updateStatus('Point deleted successfully');
-      
+
       // Clear selection if the deleted point was selected
       clearSelection();
-      
+
       return true;
     } catch (error) {
       console.error('Error deleting point:', error);
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
-      
+
       await this.diagramService.reloadDiagram();
       return false;
     } finally {
       setLoading(false);
     }
   }
-  
+
   /**
    * Update point positions in the diagram
    */
   async updatePointPositions(pointsAndVector: MovePointsByDeltaData): Promise<boolean> {
-  
+
     if (pointsAndVector.pointIris.length === 0) {
       return false;
     }
-    
+
     // Get the diagram data
     const currentDiagram = get(diagramData);
     if (!currentDiagram) return false;
-    
+
     // Find all glued points that need to be updated
     const allPointsToUpdate = new Set<string>(pointsAndVector.pointIris);
-    
+
     // For each selected point, add its glued points
     pointsAndVector.pointIris.forEach(pointIri => {
       const gluedPoints = currentDiagram.getGluedPoints(pointIri);
@@ -257,72 +257,350 @@ export class PointService {
         allPointsToUpdate.add(gluedPointIri);
       });
     });
-    
+
     // Create the updated movement data
     const updatedPointsAndVector: MovePointsByDeltaData = {
       pointIris: Array.from(allPointsToUpdate),
       deltaVector: pointsAndVector.deltaVector
     };
-    
+
     setLoading(true);
     updateStatus('Updating point positions...');
-    
+
     try {
       // Get current namespace
       const namespace = get(cimNamespace);
       // Build update query
       const query = this.pointQueryBuilder.buildUpdateDiagramPointPositionsByVectorQuery(updatedPointsAndVector, namespace);
-      
+
       // Execute update
       await this.sparqlService.executeUpdate(query);
-      
-      updateStatus(`Updated ${updatedPointsAndVector.pointIris.length} points`);      
+
+      updateStatus(`Updated ${updatedPointsAndVector.pointIris.length} points`);
       return true;
     } catch (error) {
       console.error('Error updating point positions:', error);
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
-      
-      await this.diagramService.reloadDiagram();     
+
+      await this.diagramService.reloadDiagram();
       return false;
     } finally {
       setLoading(false);
     }
   }
-  
+
   /**
    * Update point positions with absolute coordinates
    */
   async updatePointPositionsAbsolute(
-    updateData: { points: string[], newPositions: Point2D[] }
+      updateData: { points: string[], newPositions: Point2D[] }
   ): Promise<boolean> {
     if (updateData.points.length === 0 || updateData.points.length !== updateData.newPositions.length) {
       return false;
     }
-    
+
     setLoading(true);
     updateStatus('Updating point positions...');
-    
+
     try {
       // Get current namespace
       const namespace = get(cimNamespace);
-      
+
       const query = this.pointQueryBuilder.buildUpdateDiagramPointPositionsQuery(
-        updateData.points,
-        updateData.newPositions,
-        namespace
+          updateData.points,
+          updateData.newPositions,
+          namespace
       );
 
       // Execute update
       await this.sparqlService.executeUpdate(query);
-      
+
       updateStatus(`Updated ${updateData.points.length} points`);
       return true;
     } catch (error) {
       console.error('Error updating point positions:', error);
       updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
-      
+
       await this.diagramService.reloadDiagram();
-      return false; 
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // ========== TRANSFORMATION OPERATIONS ==========
+
+  /**
+   * Validate selected points for transformation operations
+   */
+  private validateSelectedPointsForTransformation(operation: string = 'transform'): {
+    selectedPoints: PointModel[];
+    validationError: string | null;
+  } {
+    const currentState = get(interactionState);
+    const currentDiagram = get(diagramData);
+
+    if (!currentDiagram || currentState.selectedPoints.size === 0) {
+      return { selectedPoints: [], validationError: `Nothing selected to ${operation}` };
+    }
+
+    const selectedPointIris = Array.from(currentState.selectedPoints);
+    const selectedPoints = currentDiagram.points.filter(p => selectedPointIris.includes(p.iri));
+
+    if (selectedPoints.length === 0) {
+      return { selectedPoints: [], validationError: `No valid points to ${operation}` };
+    }
+
+    return { selectedPoints, validationError: null };
+  }
+
+  /**
+   * Calculate center point from a collection of points
+   */
+  private calculatePointsCenter(points: PointModel[]): Point2D {
+    if (points.length === 0) {
+      return { x: 0, y: 0 };
+    }
+
+    let sumX = 0;
+    let sumY = 0;
+
+    points.forEach(point => {
+      sumX += point.x;
+      sumY += point.y;
+    });
+
+    return {
+      x: sumX / points.length,
+      y: sumY / points.length
+    };
+  }
+
+  /**
+   * Get rotation trigonometric values
+   */
+  private getRotationTrigValues(degrees: number) {
+    const radians = (degrees * Math.PI) / 180;
+    return {
+      sin: Math.sin(radians),
+      cos: Math.cos(radians)
+    };
+  }
+
+  /**
+   * Calculate rotated positions for specific points
+   */
+  private calculateRotatedPositionsForPoints(
+      points: PointModel[],
+      center: Point2D,
+      sin: number,
+      cos: number
+  ): { point: PointModel; newX: number; newY: number }[] {
+    const pointsToRotate: { point: PointModel; newX: number; newY: number }[] = [];
+
+    points.forEach(point => {
+      // Apply rotation matrix
+      const dx = point.x - center.x;
+      const dy = point.y - center.y;
+      const newX = center.x + (dx * cos - dy * sin);
+      const newY = center.y + (dx * sin + dy * cos);
+
+      pointsToRotate.push({ point, newX, newY });
+    });
+
+    return pointsToRotate;
+  }
+
+  /**
+   * Calculate horizontally mirrored positions for specific points
+   */
+  private calculateHorizontallyMirroredPositionsForPoints(
+      points: PointModel[],
+      center: Point2D
+  ): { point: PointModel; newX: number; newY: number }[] {
+    const pointsToMirror: { point: PointModel; newX: number; newY: number }[] = [];
+
+    points.forEach(point => {
+      // Apply horizontal mirroring
+      const newX = 2 * center.x - point.x;
+      const newY = point.y; // Y coordinate stays the same for horizontal mirroring
+      pointsToMirror.push({ point, newX, newY });
+    });
+
+    return pointsToMirror;
+  }
+
+  /**
+   * Calculate vertically mirrored positions for specific points
+   */
+  private calculateVerticallyMirroredPositionsForPoints(
+      points: PointModel[],
+      center: Point2D
+  ): { point: PointModel; newX: number; newY: number }[] {
+    const pointsToMirror: { point: PointModel; newX: number; newY: number }[] = [];
+
+    points.forEach(point => {
+      // Apply vertical mirroring
+      const newX = point.x; // X coordinate stays the same for vertical mirroring
+      const newY = 2 * center.y - point.y;
+      pointsToMirror.push({ point, newX, newY });
+    });
+
+    return pointsToMirror;
+  }
+
+  /**
+   * Update local point positions in the model
+   */
+  private updateLocalPointPositions(pointsToUpdate: { point: PointModel; newX: number; newY: number }[]) {
+    pointsToUpdate.forEach(({ point, newX, newY }) => {
+      point.x = newX;
+      point.y = newY;
+    });
+
+    // Update the diagram
+    diagramData.set(get(diagramData));
+  }
+
+  /**
+   * Prepare position update data for SPARQL
+   */
+  private preparePositionUpdateData(pointsToUpdate: { point: PointModel; newX: number; newY: number }[]) {
+    return {
+      points: pointsToUpdate.map(({ point }) => point.iri),
+      newPositions: pointsToUpdate.map(({ newX, newY }) => ({ x: newX, y: newY }))
+    };
+  }
+
+  /**
+   * Handle transformation errors
+   */
+  private async handleTransformationError(error: any, operation: string = 'transformation') {
+    console.error(`Error during ${operation}:`, error);
+    updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
+
+    await this.diagramService.reloadDiagram();
+  }
+
+  /**
+   * Rotate selected points around their center
+   */
+  async rotateSelectedPoints(degrees: number): Promise<boolean> {
+    const { selectedPoints, validationError } = this.validateSelectedPointsForTransformation('rotate');
+
+    if (validationError) {
+      updateStatus(validationError);
+      return false;
+    }
+
+    // Calculate rotation center based on selected points only
+    const center = this.calculatePointsCenter(selectedPoints);
+    const { sin, cos } = this.getRotationTrigValues(degrees);
+
+    // Start operation
+    setLoading(true);
+    updateStatus(`Rotating ${selectedPoints.length} points...`);
+
+    try {
+      // Calculate new positions for selected points only
+      const pointsToRotate = this.calculateRotatedPositionsForPoints(selectedPoints, center, sin, cos);
+
+      // Update local model first
+      this.updateLocalPointPositions(pointsToRotate);
+
+      // Prepare data for SPARQL update
+      const updateData = this.preparePositionUpdateData(pointsToRotate);
+
+      // Send update to server
+      await this.updatePointPositionsAbsolute(updateData);
+
+      updateStatus(`Rotated ${selectedPoints.length} points by ${degrees} degrees`);
+      return true;
+    } catch (error) {
+      await this.handleTransformationError(error, 'rotation');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  /**
+   * Mirror selected points horizontally around their center
+   */
+  async mirrorSelectedPointsHorizontally(): Promise<boolean> {
+    const { selectedPoints, validationError } = this.validateSelectedPointsForTransformation('mirror');
+
+    if (validationError) {
+      updateStatus(validationError);
+      return false;
+    }
+
+    // Calculate the center of the selected points only
+    const center = this.calculatePointsCenter(selectedPoints);
+
+    // Start operation
+    setLoading(true);
+    updateStatus(`Mirroring ${selectedPoints.length} points horizontally...`);
+
+    try {
+      // Calculate new positions for selected points only
+      const pointsToMirror = this.calculateHorizontallyMirroredPositionsForPoints(selectedPoints, center);
+
+      // Update local model first
+      this.updateLocalPointPositions(pointsToMirror);
+
+      // Prepare data for SPARQL update
+      const updateData = this.preparePositionUpdateData(pointsToMirror);
+
+      // Send update to server
+      await this.updatePointPositionsAbsolute(updateData);
+
+      updateStatus(`Mirrored ${selectedPoints.length} points horizontally`);
+      return true;
+    } catch (error) {
+      await this.handleTransformationError(error, 'horizontal mirroring');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  /**
+   * Mirror selected points vertically around their center
+   */
+  async mirrorSelectedPointsVertically(): Promise<boolean> {
+    const { selectedPoints, validationError } = this.validateSelectedPointsForTransformation('mirror');
+
+    if (validationError) {
+      updateStatus(validationError);
+      return false;
+    }
+
+    // Calculate the center of the selected points only
+    const center = this.calculatePointsCenter(selectedPoints);
+
+    // Start operation
+    setLoading(true);
+    updateStatus(`Mirroring ${selectedPoints.length} points vertically...`);
+
+    try {
+      // Calculate new positions for selected points only
+      const pointsToMirror = this.calculateVerticallyMirroredPositionsForPoints(selectedPoints, center);
+
+      // Update local model first
+      this.updateLocalPointPositions(pointsToMirror);
+
+      // Prepare data for SPARQL update
+      const updateData = this.preparePositionUpdateData(pointsToMirror);
+
+      // Send update to server
+      await this.updatePointPositionsAbsolute(updateData);
+
+      updateStatus(`Mirrored ${selectedPoints.length} points vertically`);
+      return true;
+    } catch (error) {
+      await this.handleTransformationError(error, 'vertical mirroring');
+      return false;
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Move rotation and mirroring operations from ObjectService to PointService
for better architectural separation. Operations now work exclusively on
selected points rather than entire objects, improving granular control.

- Renamed: rotateSelectedObjects → rotateSelectedPoints
- Renamed: mirrorSelectedObjects → mirrorSelectedPoints
- Updated UI components to use PointService for transformations